### PR TITLE
Simply fixes the package.json JSON structure.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "dirtyshare",
   "description": "Peer to Peer File Sharing with Node and Socket.io",
   "author": "Rich Jones <rich@gun.io>",
+  "version": "0.0.1",
   "dependencies": {
     "socket.io": "0.8.x",
-    "express": "2.5.x",
+    "express": "2.5.x"
   },
   "engine": "node >= 0.4.1"
 }


### PR DESCRIPTION
Also a previous JSON syntax error:

npm ERR! Couldn't read dependencies.
npm ERR! Failed to parse json
npm ERR! Unexpected token }
npm ERR! File: /Users/jamie/dev/scratchpad/DirtyShare/package.json
npm ERR! JSON.parse Failed to parse package.json data.
npm ERR! JSON.parse package.json must be actual JSON, not just JavaScript.
npm ERR! JSON.parse 
npm ERR! JSON.parse This is not a bug in npm.
npm ERR! JSON.parse Tell the package author to fix their package.json file.
npm ERR! 
npm ERR! System Darwin 11.2.0
npm ERR! command "node" "/Users/jamie/.nodelocal/bin/npm" "install" "."
npm ERR! cwd /Users/jamie/dev/scratchpad/DirtyShare
npm ERR! node -v v0.6.5
npm ERR! npm -v 1.1.0-beta-4
npm ERR! file /Users/jamie/dev/scratchpad/DirtyShare/package.json
npm ERR! code EJSONPARSE
npm ERR! message Failed to parse json
npm ERR! message Unexpected token }
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/jamie/dev/scratchpad/DirtyShare/npm-debug.log
npm not ok
