### PR TITLE
Add a basic config file and jQuery templating to index.html.

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,0 +1,3 @@
+Server:
+  siteDomain: example.org
+  port: 2000

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
 					 "\"You Dirty Bastards!\"", 
 					 "\"Sheer And Utter Filth!\"", 
 					 "\"What a Shame!\"", 
+                                         "\"Makes me want to punch kittens!\"",
 					];
 				$('#subheader').html('<i>' + filth[Math.floor(Math.random()*filth.length)] + '</i>');
 			});
@@ -56,7 +57,7 @@
 
         <script type="text/javascript">
             $(document).ready(function() {
-				$('#shareurl').html('<b>http://share.gun.io/' + $.url().segment(1) + '</b>');
+                $('#shareurl').html('<b>http://${domain}/' + $.url().segment(1) + '</b>');
 			});
 		</script>
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "version": "0.0.1",
   "dependencies": {
     "socket.io": "0.8.x",
-    "express": "2.5.x"
+    "express": "2.5.x",
+    "config": "0.4.9"
   },
   "engine": "node >= 0.4.1"
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "socket.io": "0.8.x",
     "express": "2.5.x",
-    "config": "0.4.9"
+    "config": "0.4.9",
+    "jqtpl": "1.0.7"
   },
   "engine": "node >= 0.4.1"
 }

--- a/server.js
+++ b/server.js
@@ -4,9 +4,12 @@ var app = require('express').createServer()
   ,	express = require('express')
   , io = require('socket.io').listen(app);
 
+// Load the config file
+var config = require('config').Server;
+
  // App Stuff
 app.use('/public', express.static(__dirname + '/public'));
-app.listen(2000);
+app.listen(config.port);
 
 app.get('/', function (req, res) {
   res.redirect('/' + randomString());

--- a/server.js
+++ b/server.js
@@ -1,8 +1,10 @@
 // Requirements
 
 var app = require('express').createServer()
-  ,	express = require('express')
-  , io = require('socket.io').listen(app);
+  , express = require('express')
+  , io = require('socket.io').listen(app)
+  , jqtpl = require("jqtpl");
+
 
 // Load the config file
 var config = require('config').Server;
@@ -10,13 +12,16 @@ var config = require('config').Server;
  // App Stuff
 app.use('/public', express.static(__dirname + '/public'));
 app.listen(config.port);
+app.set("view engine", "html");
+app.set("view options", {layout: false});
+app.register(".html", require("jqtpl").express);
 
 app.get('/', function (req, res) {
   res.redirect('/' + randomString());
 });
 
 app.get('/:hash', function (req, res) {
-  res.sendfile(__dirname + '/index.html');
+  res.render (__dirname + '/index', {domain: config.siteDomain});
 });
 
 // P2P Stuff


### PR DESCRIPTION
Hi,

Simple patch, adding in a basic configuration file and jQuery templating rendered by express. The templating doesn't need to be jqtpl if you have something else in mind.

It would be useful to have this for a user authentication feature I'm working on (https://github.com/jdpaton/DirtyShare/tree/user-auth). The gist there is, that you can add/invite users via their Google email and have them authenticate with Googles' OpenID, which is were sessions and such would be a nice-to-have! 

-- Jamie
